### PR TITLE
Add CVE ingore list

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,15 @@
+steps:
+  - label: ":golang: Build"
+    command: "cd src && go build ."
+    plugins:
+      - golang#v2.0.0:
+          version: 1.21
+          import: github.com/buildkite/agent
+
+  - label: ":test-analytics: Test"
+    command: "cd src && go test ./..."
+    plugins:
+      - golang#v2.0.0:
+          version: 1.21
+          import: github.com/buildkite/agent
+

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,6 +1,6 @@
 module github.com/cultureamp/ecrscanresults
 
-go 1.20
+go 1.21
 
 require (
 	github.com/MarvinJWendt/testza v0.4.1

--- a/src/main.go
+++ b/src/main.go
@@ -117,7 +117,7 @@ func runCommand(ctx context.Context, pluginConfig Config, agent buildkite.Agent)
 	annotationCtx := report.AnnotationContext{
 		Image:                     imageID,
 		ImageLabel:                pluginConfig.ImageLabel,
-		ScanFindings:              *findings.ImageScanFindings,
+		ScanFindings:              findings.ImageScanFindings,
 		CriticalSeverityThreshold: pluginConfig.CriticalSeverityThreshold,
 		HighSeverityThreshold:     pluginConfig.HighSeverityThreshold,
 	}

--- a/src/main.go
+++ b/src/main.go
@@ -66,7 +66,6 @@ func main() {
 			// annotation fails. We annotate to notify the user of the issue,
 			// otherwise it would be lost in the log.
 			annotation := fmt.Sprintf("ECR scan results plugin could not create a result for the image %s", "")
-			fmt.Println(annotation)
 			_ = agent.Annotate(ctx, annotation, "error", hash(pluginConfig.Repository))
 		}
 	}


### PR DESCRIPTION
This PR introduces support for ignoring CVEs.

Simply pass CVEs you want to ignore in `--ignore` flag as a comma-separated list in a string.
