### PR TITLE
Introduce min severity level support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,13 +92,17 @@ reports harder to scan visually.
 
 When supplied, this is used to ignore specific CVEs.
 
+### `min-severity` (Optional, string)
+
+Include vulnerabilities with severity >= `min-severity` in the report. Defaults
+to "high". Note: "unknown" > "critical". 
+
 ## Requirements
 
 ### ECR Scan on Push
 
-This plugin assumes that the ECR repository has the `ScanOnPush` setting set (see
-the [AWS
-docs](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html)
+This plugin assumes that the ECR repository has the `ScanOnPush` setting set
+(see the [AWS docs](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning.html)
 for more information). By default this is not set on AWS ECR repositories.
 
 ### Agent role requires the ecr:DescribeImages permission

--- a/src/registry/ecr.go
+++ b/src/registry/ecr.go
@@ -205,17 +205,17 @@ func FilterMinSeverity(minSeverity types.FindingSeverity) FindingFilter {
 
 func severityLevel(severity types.FindingSeverity) int {
 	switch severity {
-	case types.FindingSeverityInformational:
-		return 0
-	case types.FindingSeverityLow:
-		return 1
-	case types.FindingSeverityMedium:
-		return 2
-	case types.FindingSeverityHigh:
-		return 3
-	case types.FindingSeverityCritical:
-		return 4
 	case types.FindingSeverityUndefined:
+		return 0
+	case types.FindingSeverityInformational:
+		return 1
+	case types.FindingSeverityLow:
+		return 2
+	case types.FindingSeverityMedium:
+		return 3
+	case types.FindingSeverityHigh:
+		return 4
+	case types.FindingSeverityCritical:
 		return 5
 	default: // unknown severity
 		return -1

--- a/src/registry/ecr.go
+++ b/src/registry/ecr.go
@@ -117,7 +117,7 @@ func (r *RegistryScan) WaitForScanFindings(ctx context.Context, digestInfo Regis
 	})
 }
 
-func (r *RegistryScan) GetScanFindings(ctx context.Context, digestInfo RegistryInfo, ignoreList []string) (*ScanFindings, error) {
+func (r *RegistryScan) GetScanFindings(ctx context.Context, digestInfo RegistryInfo) (*ScanFindings, error) {
 	pg := ecr.NewDescribeImageScanFindingsPaginator(r.Client, &ecr.DescribeImageScanFindingsInput{
 		RegistryId:     &digestInfo.RegistryID,
 		RepositoryName: &digestInfo.Name,
@@ -150,26 +150,74 @@ func (r *RegistryScan) GetScanFindings(ctx context.Context, digestInfo RegistryI
 		enhancedFindings = append(enhancedFindings, page.ImageScanFindings.EnhancedFindings...)
 	}
 
-	filteredFindings := []types.ImageScanFinding{}
-
-	for _, finding := range findings {
-		if !slices.Contains(ignoreList, *finding.Name) {
-			filteredFindings = append(filteredFindings, finding)
-		}
-	}
-
-	filteredEnhancedFindings := []types.EnhancedImageScanFinding{}
-
-	for _, finding := range enhancedFindings {
-		if !slices.Contains(ignoreList, *finding.Title) {
-			filteredEnhancedFindings = append(filteredEnhancedFindings, finding)
-		}
-	}
-
-	imageScanFindings.Findings = filteredFindings
-	imageScanFindings.EnhancedFindings = filteredEnhancedFindings
+	imageScanFindings.Findings = findings
+	imageScanFindings.EnhancedFindings = enhancedFindings
 
 	return &ScanFindings{
 		ImageScanFindings: imageScanFindings,
 	}, nil
+}
+
+// Filters
+
+type FindingFilter = func(types.ImageScanFinding) bool
+
+func FilterFindings(allFindings ScanFindings, filters ...FindingFilter) ScanFindings {
+	filteredFindings := ScanFindings{
+		ImageScanFindings: types.ImageScanFindings{
+			FindingSeverityCounts:        make(map[string]int32),
+			Findings:                     []types.ImageScanFinding{},
+			EnhancedFindings:             allFindings.EnhancedFindings, // we are not using enhanced findings just yet
+			ImageScanCompletedAt:         allFindings.ImageScanCompletedAt,
+			VulnerabilitySourceUpdatedAt: allFindings.VulnerabilitySourceUpdatedAt,
+		},
+	}
+	for _, finding := range allFindings.Findings {
+		keep := true
+
+		for _, filter := range filters {
+			if !filter(finding) {
+				keep = false
+				break
+			}
+		}
+
+		if keep {
+			filteredFindings.Findings = append(filteredFindings.Findings, finding)
+			filteredFindings.FindingSeverityCounts[string(finding.Severity)]++
+		}
+	}
+
+	return filteredFindings
+}
+
+func FilterIgnoredNames(namesToIgnore []string) FindingFilter {
+	return func(finding types.ImageScanFinding) bool {
+		return !slices.Contains(namesToIgnore, *finding.Name)
+	}
+}
+
+func FilterMinSeverity(minSeverity types.FindingSeverity) FindingFilter {
+	return func(finding types.ImageScanFinding) bool {
+		return severityLevel(finding.Severity) >= severityLevel(minSeverity)
+	}
+}
+
+func severityLevel(severity types.FindingSeverity) int {
+	switch severity {
+	case types.FindingSeverityInformational:
+		return 0
+	case types.FindingSeverityLow:
+		return 1
+	case types.FindingSeverityMedium:
+		return 2
+	case types.FindingSeverityHigh:
+		return 3
+	case types.FindingSeverityCritical:
+		return 4
+	case types.FindingSeverityUndefined:
+		return 5
+	default: // unknown severity
+		return -1
+	}
 }

--- a/src/registry/ecr_test.go
+++ b/src/registry/ecr_test.go
@@ -3,6 +3,8 @@ package registry
 import (
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecr/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -52,4 +54,107 @@ func TestRegistryInfoFromURLFails(t *testing.T) {
 	assert.ErrorContains(t, err, "invalid registry URL")
 
 	assert.Equal(t, RegistryInfo{}, info)
+}
+
+func TestFilterFindings(t *testing.T) {
+	sampleFindings := ScanFindings{
+		ImageScanFindings: types.ImageScanFindings{
+			Findings: []types.ImageScanFinding{
+				{
+					Name:     aws.String("cve-1"),
+					Severity: types.FindingSeverityLow,
+				},
+				{
+					Name:     aws.String("cve-2"),
+					Severity: types.FindingSeverityMedium,
+				},
+				{
+					Name:     aws.String("cve-3"),
+					Severity: types.FindingSeverityHigh,
+				},
+				{
+					Name:     aws.String("cve-4"),
+					Severity: types.FindingSeverityHigh,
+				},
+			},
+		},
+	}
+
+	type args struct {
+		allFindings ScanFindings
+		filters     []FindingFilter
+	}
+	tests := []struct {
+		name   string
+		args   args
+		wantFn func(ScanFindings) bool
+	}{
+		{
+			name: "keep all",
+			args: args{
+				allFindings: sampleFindings,
+				filters: []FindingFilter{
+					func(types.ImageScanFinding) bool { return true },
+				},
+			},
+			wantFn: func(sf ScanFindings) bool {
+				return len(sf.Findings) == len(sampleFindings.Findings)
+			},
+		},
+		{
+			name: "skip all",
+			args: args{
+				allFindings: sampleFindings,
+				filters: []FindingFilter{
+					func(types.ImageScanFinding) bool { return false },
+				},
+			},
+			wantFn: func(sf ScanFindings) bool {
+				return len(sf.Findings) == 0
+			},
+		},
+		{
+			name: "ignore cev-2",
+			args: args{
+				allFindings: sampleFindings,
+				filters: []FindingFilter{
+					FilterIgnoredNames([]string{"cve-2"}),
+				},
+			},
+			wantFn: func(sf ScanFindings) bool {
+				return len(sf.Findings) == 3
+			},
+		},
+		{
+			name: "sev high+",
+			args: args{
+				allFindings: sampleFindings,
+				filters: []FindingFilter{
+					FilterMinSeverity(types.FindingSeverityHigh),
+				},
+			},
+			wantFn: func(sf ScanFindings) bool {
+				return len(sf.Findings) == 2 && sf.FindingSeverityCounts["HIGH"] == 2
+			},
+		},
+		{
+			name: "multiple filters",
+			args: args{
+				allFindings: sampleFindings,
+				filters: []FindingFilter{
+					FilterMinSeverity(types.FindingSeverityHigh),
+					func(types.ImageScanFinding) bool { return false },
+				},
+			},
+			wantFn: func(sf ScanFindings) bool {
+				return len(sf.Findings) == 0
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FilterFindings(tt.args.allFindings, tt.args.filters...)
+			assert.True(t, tt.wantFn(got))
+		})
+	}
 }

--- a/src/report/annotation_test.go
+++ b/src/report/annotation_test.go
@@ -2,6 +2,7 @@ package report_test
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/MarvinJWendt/testza"
@@ -104,4 +105,54 @@ func TestReports(t *testing.T) {
 			testza.AssertNoError(t, err)
 		})
 	}
+}
+
+func TestReportRender(t *testing.T) {
+	data := report.AnnotationContext{
+		Image: registry.RegistryInfo{
+			RegistryID: "0123456789",
+			Region:     "us-west-2",
+			Name:       "test-repo",
+			Tag:        "digest-value",
+		},
+		ImageLabel: "windowsservercore-ltsc2022",
+		ScanFindings: types.ImageScanFindings{
+			FindingSeverityCounts: map[string]int32{
+				"HIGH": 1,
+			},
+			Findings: []types.ImageScanFinding{
+				{
+					Name:        aws.String("CVE-2019-5188"),
+					Description: aws.String("A code execution vulnerability exists in the directory rehashing functionality of E2fsprogs e2fsck 1.45.4. A specially crafted ext4 directory can cause an out-of-bounds write on the stack, resulting in code execution. An attacker can corrupt a partition to trigger this vulnerability."),
+					Uri:         aws.String("http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-5188"),
+					Severity:    "HIGH",
+					Attributes: []types.Attribute{
+						{
+							Key:   aws.String("package_version"),
+							Value: aws.String("1.44.1-1ubuntu1.1"),
+						},
+						{
+							Key:   aws.String("package_name"),
+							Value: aws.String("e2fsprogs"),
+						},
+						{
+							Key:   aws.String("CVSS2_VECTOR"),
+							Value: aws.String("AV:L/AC:L/Au:N/C:P/I:P/A:P"),
+						},
+						{
+							Key:   aws.String("CVSS2_SCORE"),
+							Value: aws.String("4.6"),
+						},
+					},
+				},
+			},
+		},
+		CriticalSeverityThreshold: 0,
+		HighSeverityThreshold:     0,
+	}
+
+	result, err := data.Render()
+	os.WriteFile("./testdata/render.html", result, 0644)
+
+	testza.AssertNoError(t, err)
 }

--- a/src/report/testdata/render.html
+++ b/src/report/testdata/render.html
@@ -1,0 +1,49 @@
+
+
+
+
+<h4>Vulnerability summary for "windowsservercore-ltsc2022"</h4>
+<p class="h6 regular italic">test-repo:digest-value</p>
+
+
+<dl class="flex flex-wrap mxn1">
+
+
+<div class="m1 p1 mr3">
+<dt>High</dt>
+<dd><h1 class="m0 red">1</h1>
+</dd>
+</div>
+
+</dl>
+
+
+<details>
+<summary>Vulnerability details</summary>
+<div>
+<table>
+<tr>
+<th>CVE</th>
+<th>Severity</th>
+<th>Effects</th>
+<th>CVSS score</th>
+<th>Vector</th>
+</tr>
+
+
+<tr>
+<td><a href="http://people.ubuntu.com/~ubuntu-security/cve/CVE-2019-5188">CVE-2019-5188</a></td>
+<td>High</td>
+<td>e2fsprogs 1.44.1-1ubuntu1.1</td>
+<td>4.6</td>
+<td><a href="https://nvd.nist.gov/vuln-metrics/cvss/v2-calculator?vector=(AV%3aL%2fAC%3aL%2fAu%3aN%2fC%3aP%2fI%3aP%2fA%3aP)">AV:L/AC:L/Au:N/C:P/I:P/A:P</a></td>
+</tr>
+
+</table>
+</div>
+</details>
+
+<p class="p1">
+<i>scan completed: <span title="&lt;nil&gt;"></span></i> |
+<i>source updated: <span title="&lt;nil&gt;"></span></i>
+</p>


### PR DESCRIPTION
📦 

- Makes filtering more composable
- Adds support to only show `MIN_SEVERITY`+ vulnerabilities in the report (defaults to HIGH)
- Renders HTML in report tests to make local debugging easier