### PR TITLE
Log fatal error waiting fails [PLT-1609] 

### DIFF
--- a/main.go
+++ b/main.go
@@ -116,7 +116,7 @@ func runCommand(ctx context.Context, pluginConfig Config, agent buildkite.Agent)
 	buildkite.LogGroupf(":ecr: Creating ECR scan results report for %s\n", imageID)
 	err = scan.WaitForScanFindings(ctx, imageDigest)
 	if err != nil {
-		return runtimeerrors.NonFatal("could not retrieve scan results", err)
+		return fmt.Errorf("could not retrieve scan results %w", err)
 	}
 
 	buildkite.Log("report ready, retrieving ...")

--- a/src/registry/ecr.go
+++ b/src/registry/ecr.go
@@ -99,7 +99,7 @@ func (r *RegistryScan) WaitForScanFindings(ctx context.Context, digestInfo Regis
 	customRetryable := func(ctx context.Context, params *ecr.DescribeImageScanFindingsInput,
 		output *ecr.DescribeImageScanFindingsOutput, err error) (bool, error) {
 		if err != nil {
-			buildkite.Logf("error waiting for scan findings %v", err)
+			fmt.Printf("error waiting for scan findings %v\n", err)
 		}
 		return true, nil
 	}

--- a/src/registry/ecr.go
+++ b/src/registry/ecr.go
@@ -29,6 +29,11 @@ type RegistryInfo struct {
 	Tag string
 }
 
+type ECRAPI interface {
+	DescribeImageScanFindings(context.Context, *ecr.DescribeImageScanFindingsInput, ...func(*ecr.Options)) (*ecr.DescribeImageScanFindingsOutput, error)
+	DescribeImages(context.Context, *ecr.DescribeImagesInput, ...func(*ecr.Options)) (*ecr.DescribeImagesOutput, error)
+}
+
 func (i RegistryInfo) String() string {
 	return fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s:%s", i.RegistryID, i.Region, i.Name, i.Tag)
 }
@@ -60,14 +65,26 @@ func RegistryInfoFromURL(url string) (RegistryInfo, error) {
 }
 
 type RegistryScan struct {
-	Client *ecr.Client
+	Client          ECRAPI
+	MinAttemptDelay time.Duration
+	MaxAttemptDelay time.Duration
+	MaxTotalDelay   time.Duration
 }
 
 func NewRegistryScan(config aws.Config) (*RegistryScan, error) {
 	client := ecr.NewFromConfig(config)
 
+	// wait between attempts for between 3 and 15 secs (exponential backoff)
+	// wait for a maximum of 3 minutes
+	minAttemptDelay := 3 * time.Second
+	maxAttemptDelay := 15 * time.Second
+	maxTotalDelay := 3 * time.Minute
+
 	return &RegistryScan{
-		Client: client,
+		Client:          client,
+		MinAttemptDelay: minAttemptDelay,
+		MaxAttemptDelay: maxAttemptDelay,
+		MaxTotalDelay:   maxTotalDelay,
 	}, nil
 }
 
@@ -96,20 +113,7 @@ func (r *RegistryScan) GetLabelDigest(ctx context.Context, imageInfo RegistryInf
 }
 
 func (r *RegistryScan) WaitForScanFindings(ctx context.Context, digestInfo RegistryInfo) error {
-	customRetryable := func(ctx context.Context, params *ecr.DescribeImageScanFindingsInput,
-		output *ecr.DescribeImageScanFindingsOutput, err error) (bool, error) {
-		if err != nil {
-			fmt.Printf("error waiting for scan findings %v\n", err)
-		}
-		return true, nil
-	}
-
 	waiter := ecr.NewImageScanCompleteWaiter(r.Client)
-	// wait between attempts for between 3 and 15 secs (exponential backoff)
-	// wait for a maximum of 3 minutes
-	minAttemptDelay := 3 * time.Second
-	maxAttemptDelay := 15 * time.Second
-	maxTotalDelay := 3 * time.Minute
 
 	return waiter.Wait(ctx, &ecr.DescribeImageScanFindingsInput{
 		RegistryId:     &digestInfo.RegistryID,
@@ -117,10 +121,23 @@ func (r *RegistryScan) WaitForScanFindings(ctx context.Context, digestInfo Regis
 		ImageId: &types.ImageIdentifier{
 			ImageDigest: &digestInfo.Tag,
 		},
-	}, maxTotalDelay, func(opts *ecr.ImageScanCompleteWaiterOptions) {
+	}, r.MaxAttemptDelay, func(opts *ecr.ImageScanCompleteWaiterOptions) {
+		/*
+			We must copy this function outside the closure to avoid an infinite loop
+			If we copy it inside the closure the compiler will assign it to a pointer
+			to itself
+		*/
+		defaultRetryableFunc := opts.Retryable
+		customRetryable := func(ctx context.Context, params *ecr.DescribeImageScanFindingsInput,
+			output *ecr.DescribeImageScanFindingsOutput, err error) (bool, error) {
+			if err != nil {
+				fmt.Printf("error waiting for scan findings %v\n", err)
+			}
+			return defaultRetryableFunc(ctx, params, output, err)
+		}
 		opts.LogWaitAttempts = true
-		opts.MinDelay = minAttemptDelay
-		opts.MaxDelay = maxAttemptDelay
+		opts.MinDelay = r.MinAttemptDelay
+		opts.MaxDelay = r.MaxAttemptDelay
 		opts.Retryable = customRetryable
 	})
 }


### PR DESCRIPTION
In some scenarios (for instance when the agent has DescribeImages permissions but not DescribeImageScanFindings) the waiter will retry and only return `plugin execution failed: could not retrieve scan results: exceeded max wait time for ImageScanComplete waiter`

This isn't very helpful to debug, we should throw an error and log any errors we encountered.


I initially tried to teach the waiter to fail immediately when it encountered an Access Denied error, but I could not find the explicit exception we should match on. This at least gives us the reason, even though it'll take ~3min to fail.