### PR TITLE
read cves to ignore from a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,16 @@ reports harder to scan visually.
 
 When supplied, this is used to ignore specific CVEs.
 
+### `ignore-file` (Optional, string)
+
+Read a file with a list of vulnerabilities to ignore, in the format of:
+```
+Vulnerabilities:
+  - CVE-2023-12345
+```
+
+Defaults to `.buildkite/ignored_cves.yml`
+
 ### `min-severity` (Optional, string)
 
 Include vulnerabilities with severity >= `min-severity` in the report. Defaults

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseConfigWithYAMLFile(t *testing.T) {
+	t.Setenv("IMAGE_NAME", "buildkite")
+	t.Setenv("IGNORE_FILE", "testdata/ignored.yml")
+	config, err := parseConfig()
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, config.IgnoredVulnerabilities, []string{"CVE-2023-12345", "CVE-2022-9876"})
+}
+
+func TestParseConfigMergeIgnoredCVEs(t *testing.T) {
+	t.Setenv("IMAGE_NAME", "buildkite")
+	t.Setenv("IGNORE_FILE", "testdata/ignored.yml")
+	t.Setenv("IGNORE", "CVE-2023-111")
+	config, err := parseConfig()
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, config.IgnoredVulnerabilities, []string{"CVE-2023-111", "CVE-2023-12345", "CVE-2022-9876"})
+}
+
+func TestParseConfigMergeWithoutDuplicates(t *testing.T) {
+	t.Setenv("IMAGE_NAME", "buildkite")
+	t.Setenv("IGNORE_FILE", "testdata/ignored.yml")
+	t.Setenv("IGNORE", "CVE-2023-111,CVE-2023-12345")
+	config, err := parseConfig()
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, config.IgnoredVulnerabilities, []string{"CVE-2023-111", "CVE-2023-12345", "CVE-2022-9876"})
+}
+
+func TestParseConfigWithoutYAMLFile(t *testing.T) {
+	t.Setenv("IMAGE_NAME", "buildkite")
+	t.Setenv("IGNORE_FILE", "testdata/not_such_file")
+	_, err := parseConfig()
+	assert.NoError(t, err)
+}

--- a/plugin.yml
+++ b/plugin.yml
@@ -19,6 +19,8 @@ configuration:
       type: string
     ignore:
       type: array
+    ignore-file:
+      type: string
     help:
       type: string
 

--- a/testdata/ignored.yml
+++ b/testdata/ignored.yml
@@ -1,0 +1,3 @@
+Vulnerabilities:
+  - CVE-2023-12345 # Foo
+  - CVE-2022-9876


### PR DESCRIPTION
As we continue to use this plugin the number of ignored vulnerabilities will inevitably grow.
To avoid them polluting the pipeline.yml file this allows them to be specified in a file, by default `.buildkite/ignored_cves.yml`