### PR TITLE
Exit with a specific exit code if the scan times out.

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -58,6 +58,10 @@ func main() {
 		// can be quite flakey. For this reason, we wrap most issues in a
 		// non-fatal error type.
 		if pluginConfig.FailBuildOnPluginFailure || runtimeerrors.IsFatal(err) {
+			// If timeout error, exit 75 (POSIX timer expired)
+			if registry.IsErrWaiterTimeout(err) {
+				os.Exit(75)
+			}
 			os.Exit(1)
 		} else {
 			// Attempt to annotate the build with the issue, but it's OK if the

--- a/src/registry/ecr.go
+++ b/src/registry/ecr.go
@@ -2,8 +2,11 @@ package registry
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -136,6 +139,18 @@ func (r *RegistryScan) GetLabelDigest(ctx context.Context, imageInfo ImageRefere
 	return digestInfo, nil
 }
 
+type WaiterError string
+
+func (w WaiterError) Error() string {
+	return string(w)
+}
+
+func IsErrWaiterTimeout(w error) bool {
+	return errors.Is(w, ErrWaiterTimeout)
+}
+
+var ErrWaiterTimeout WaiterError = "image scan waiter timed out"
+
 func (r *RegistryScan) WaitForScanFindings(ctx context.Context, digestInfo ImageReference) error {
 	waiter := ecr.NewImageScanCompleteWaiter(r.Client)
 
@@ -145,18 +160,45 @@ func (r *RegistryScan) WaitForScanFindings(ctx context.Context, digestInfo Image
 	maxAttemptDelay := 15 * time.Second
 	maxTotalDelay := 3 * time.Minute
 
-	err := waiter.Wait(ctx, &ecr.DescribeImageScanFindingsInput{
-		RegistryId:     &digestInfo.RegistryID,
-		RepositoryName: &digestInfo.Name,
-		ImageId: &types.ImageIdentifier{
-			ImageDigest: &digestInfo.Digest,
+	err := waiter.Wait(ctx,
+		&ecr.DescribeImageScanFindingsInput{
+			RegistryId:     &digestInfo.RegistryID,
+			RepositoryName: &digestInfo.Name,
+			ImageId: &types.ImageIdentifier{
+				ImageDigest: &digestInfo.Digest,
+			},
+			MaxResults: aws.Int32(1), // reduce the size of the return payload when waiting for the completion state
 		},
-		MaxResults: aws.Int32(1), // reduce the size of the return payload when waiting for the completion state
-	}, maxTotalDelay, func(opts *ecr.ImageScanCompleteWaiterOptions) {
-		opts.LogWaitAttempts = true
-		opts.MinDelay = minAttemptDelay
-		opts.MaxDelay = maxAttemptDelay
-	})
+		maxTotalDelay,
+		func(opts *ecr.ImageScanCompleteWaiterOptions) {
+			opts.LogWaitAttempts = true
+			opts.MinDelay = minAttemptDelay
+			opts.MaxDelay = maxAttemptDelay
+		},
+		func(opts *ecr.ImageScanCompleteWaiterOptions) {
+			/*
+				We must copy this function outside the closure to avoid an infinite loop
+				If we copy it inside the closure the compiler will assign it to a pointer
+				to itself
+			*/
+			defaultRetryableFunc := opts.Retryable
+			customRetryable := func(ctx context.Context, params *ecr.DescribeImageScanFindingsInput,
+				output *ecr.DescribeImageScanFindingsOutput, err error) (bool, error) {
+
+				if err != nil && strings.Contains(err.Error(), "AccessDeniedException") {
+					return false, err
+				}
+				if err != nil {
+					log.Printf("error waiting for scan findings: %v", err)
+				}
+				return defaultRetryableFunc(ctx, params, output, err)
+			}
+			opts.Retryable = customRetryable
+		})
+
+	if err != nil && err.Error() == "exceeded max wait time for ImageScanComplete waiter" {
+		return ErrWaiterTimeout
+	}
 
 	// It is not good style to compare the error string, but this is the only way
 	// to capture that the scan failed, but everything else is hunky dory. We


### PR DESCRIPTION
Occasionally the scan results will take longer than the timeout period to complete. This is not necessarily a result that should block a pipeline, since the scan results are unknown, and may be ok on retry.

In this case, it would be useful to be able to retry or soft_fail the buildkite step. To this end, an explicit exit code for timeouts is added.

This PR results in the plugin exiting with exit code `75` when the plugin times out. This is only applicable when the `fail-build-on-plugin-failure` option is set to true. 