### PR TITLE
bash: Stop masking exit code from Go

### DIFF
--- a/.github/workflows/bash-checks.yaml
+++ b/.github/workflows/bash-checks.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Lint
-        run: docker-compose run --rm lint
+        run: docker compose run --rm lint
 
       - name: Test
-        run: docker-compose run --rm tests
+        run: docker compose run --rm tests

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -18,4 +18,4 @@ fi
 # shellcheck source=lib/download.bash
 . "$dir/../lib/download.bash"
 
-download_binary_and_run "$@" || exit 1
+download_binary_and_run "$@"

--- a/lib/download.bash
+++ b/lib/download.bash
@@ -92,4 +92,5 @@ download_binary_and_run() {
   chmod +x ${_executable}
 
   ./${_executable}
+  return $?
 }


### PR DESCRIPTION
In #13 we introduced a new exit code, specifically for the scenario where we time out waiting for ECR to give us back the results of a scan.

We intended the exit code to trigger a soft failure in the case of timeouts (and hence avoid breaking the build on "no result"), but still hard-fail when we **do** get a result from ECR, and that result is bad (e.g. unignored critical CVEs).

Unfortunately, the hook script (which invokes the go binary) was masking the exit code with its own `exit 1` on all failures.

So let's fix that.

🍐 @swaller-bk 